### PR TITLE
Role Definition Update

### DIFF
--- a/data.subscription.tf
+++ b/data.subscription.tf
@@ -1,3 +1,0 @@
-# Get the current Subscription context
-data "azurerm_subscription" "current" {
-}

--- a/modules/terraform-azurerm-enterprise-scale-archetypes/lib/archetype_definition_es_root.tmpl.json
+++ b/modules/terraform-azurerm-enterprise-scale-archetypes/lib/archetype_definition_es_root.tmpl.json
@@ -110,7 +110,7 @@
         ],
         "role_assignments": [],
         "role_definitions": [
-            "ES Network Subnet Contributor"
+            "ES-Network-Subnet-Contributor"
         ]
     }
 }

--- a/modules/terraform-azurerm-enterprise-scale-archetypes/lib/role_definition_es_network_contributor.json
+++ b/modules/terraform-azurerm-enterprise-scale-archetypes/lib/role_definition_es_network_contributor.json
@@ -3,7 +3,7 @@
     "type": "Microsoft.Authorization/roleDefinitions",
     "apiVersion": "2018-01-01-preview",
     "properties": {
-        "roleName": "ES Network Subnet Contributor",
+        "roleName": "ES-Network-Subnet-Contributor",
         "description": "Enterprise-scale custom Role Definition. Grants full access to manage Virtual Network subnets, but no other network resources.",
         "type": "customRole",
         "permissions": [

--- a/modules/terraform-azurerm-enterprise-scale-archetypes/locals.archetype_definitions.tf
+++ b/modules/terraform-azurerm-enterprise-scale-archetypes/locals.archetype_definitions.tf
@@ -1,14 +1,11 @@
 # Load the built-in archetype definitions from the internal library path
 locals {
-  builtin_library_path               = "${path.module}/lib"
   builtin_archetype_definitions_json = tolist(fileset(local.builtin_library_path, "**archetype_definition_*.json"))
   builtin_archetype_definitions_yaml = tolist(fileset(local.builtin_library_path, "**archetype_definition_*.{yml,yaml}"))
 }
 
 # Load the custom archetype definitions from the custom library path if specified
 locals {
-  custom_library_path_specified     = try(length(local.archetype_library_path) > 0, false)
-  custom_library_path               = local.custom_library_path_specified ? replace(local.archetype_library_path, "//$/", "") : null
   custom_archetype_definitions_json = local.custom_library_path_specified ? tolist(fileset(local.custom_library_path, "**archetype_definition_*.json")) : []
   custom_archetype_definitions_yaml = local.custom_library_path_specified ? tolist(fileset(local.custom_library_path, "**archetype_definition_*.{yml,yaml}")) : []
 }

--- a/modules/terraform-azurerm-enterprise-scale-archetypes/locals.role_definitions.tf
+++ b/modules/terraform-azurerm-enterprise-scale-archetypes/locals.role_definitions.tf
@@ -39,22 +39,22 @@ locals {
 locals {
   builtin_role_definitions_map_from_json = try(length(local.builtin_role_definitions_dataset_from_json) > 0, false) ? {
     for key, value in local.builtin_role_definitions_dataset_from_json :
-    value.name => value.properties
+    uuidv5(value.name, local.scope_id) => value.properties
     if value.type == local.resource_types.role_definition
   } : null
   builtin_role_definitions_map_from_yaml = try(length(local.builtin_role_definitions_dataset_from_yaml) > 0, false) ? {
     for key, value in local.builtin_role_definitions_dataset_from_yaml :
-    value.name => value.properties
+    uuidv5(value.name, local.scope_id) => value.properties
     if value.type == local.resource_types.role_definition
   } : null
   custom_role_definitions_map_from_json = try(length(local.custom_role_definitions_dataset_from_json) > 0, false) ? {
     for key, value in local.custom_role_definitions_dataset_from_json :
-    value.name => value.properties
+    uuidv5(value.name, local.scope_id) => value.properties
     if value.type == local.resource_types.role_definition
   } : null
   custom_role_definitions_map_from_yaml = try(length(local.custom_role_definitions_dataset_from_yaml) > 0, false) ? {
     for key, value in local.custom_role_definitions_dataset_from_yaml :
-    value.name => value.properties
+    uuidv5(value.name, local.scope_id) => value.properties
     if value.type == local.resource_types.role_definition
   } : null
 }

--- a/modules/terraform-azurerm-enterprise-scale-archetypes/locals.tf
+++ b/modules/terraform-azurerm-enterprise-scale-archetypes/locals.tf
@@ -17,6 +17,16 @@ locals {
   default_location       = var.default_location
 }
 
+# The following locals are used to define the built-in
+# library path, and determine whether a custom library
+# path has been provided to enable conditional logic on
+# loading configuration files from the library path(s).
+locals {
+  builtin_library_path          = "${path.module}/lib"
+  custom_library_path_specified = try(length(local.archetype_library_path) > 0, false)
+  custom_library_path           = local.custom_library_path_specified ? replace(local.archetype_library_path, "//$/", "") : null
+}
+
 # The following locals are used to define base Azure
 # provider paths and resource types
 locals {

--- a/modules/terraform-azurerm-enterprise-scale-archetypes/locals.tf
+++ b/modules/terraform-azurerm-enterprise-scale-archetypes/locals.tf
@@ -44,6 +44,6 @@ locals {
     policy_definition     = "${local.scope_id}/providers/Microsoft.Authorization/policyDefinitions/"
     policy_set_definition = "${local.scope_id}/providers/Microsoft.Authorization/policySetDefinitions/"
     role_assignment       = "${local.scope_id}/providers/Microsoft.Authorization/roleAssignments/"
-    role_definition       = "${local.scope_id}/providers/Microsoft.Authorization/roleDefinitions/"
+    role_definition       = "/providers/Microsoft.Authorization/roleDefinitions/"
   }
 }

--- a/modules/terraform-azurerm-enterprise-scale-archetypes/variables.tf
+++ b/modules/terraform-azurerm-enterprise-scale-archetypes/variables.tf
@@ -37,13 +37,13 @@ variable "archetype_id" {
 variable "archetype_parameters" {
   type        = map(any)
   description = "OPTIONAL: If specified, will use the specified parameters to override archetype defaults."
-  default     = null
+  default     = {}
 }
 
 variable "archetype_library_path" {
   type        = string
   description = "OPTIONAL: If specified, sets the path to a custom library folder for archetype artefacts."
-  default     = null
+  default     = ""
 
   # validation {
   #   condition     = fileexists(var.archetype_library_path) // does not work with a directory
@@ -54,7 +54,6 @@ variable "archetype_library_path" {
 variable "default_location" {
   type        = string
   description = "OPTIONAL: If specified, will use set the default location used for resource deployments where needed."
-  default     = "eastus"
 
   # Need to add validation covering all Azure locations
 }

--- a/resources.role_definitions.tf
+++ b/resources.role_definitions.tf
@@ -9,7 +9,7 @@ resource "azurerm_role_definition" "enterprise_scale" {
   role_definition_id = basename(each.key)
 
   # Mandatory resource attributes
-  name  = each.value.template.roleName
+  name  = "[${upper(local.es_root_id)}] ${each.value.template.roleName}"
   scope = each.value.scope_id
 
   permissions {

--- a/variables.tf
+++ b/variables.tf
@@ -84,7 +84,7 @@ variable "es_custom_landing_zones" {
 variable "es_archetype_library_path" {
   type        = string
   description = "OPTIONAL: If specified, sets the path to a custom library folder for archetype artefacts."
-  default     = null
+  default     = ""
 
   # validation {
   #   condition     = fileexists(var.es_archetype_library_path) // does not work with a directory


### PR DESCRIPTION
This PR introduces a couple of changes.

1. The vairable `es_archetype_library_path` is now optional, allowing the module to be run with only specifying an input value for `es_root_parent_id`
2. Role Definitions are now created with a predicatable UUID generated from the template `name` value and the scope of the deployment, using the `uuidv5()` function. This is a breaking change as the creation of a new UUID will force recreation of existing Role Definitions, however this was deemed necessary to allow multiple Role Definition deployments from a single template, and the ability to deploy the module multiple times in a single Tenant.